### PR TITLE
feat(var): adding variables to filter min and max sizes

### DIFF
--- a/src/worldmap.test.ts
+++ b/src/worldmap.test.ts
@@ -370,6 +370,7 @@ describe('Worldmap', () => {
         mapCenterLongitude: 0,
         initialZoom: 1,
         colors: ['red', 'blue', 'green'],
+        replaceVariables: (interpolation: string) => {}
       },
       tileServer: 'CartoDB Positron',
     };

--- a/src/worldmap.ts
+++ b/src/worldmap.ts
@@ -128,7 +128,7 @@ export default class WorldMap {
       return !(this.ctrl.panel.hideEmpty && _.isNil(o.value)) 
           && !(this.ctrl.panel.hideZero && o.value === 0)
           // The result of parseInt in case of "No Limit" or any other numberless string will be a NaN. 
-          // In that case all "not numbers" should invalidate the filter and ignored.
+          // In that case all "not numbers" should invalidate the filter and be ignored.
           && ([undefined, NaN, 0, ''].includes(minValue) || o.value >= minValue)
           && ([undefined, NaN, ''].includes(maxValue) || o.value <= maxValue)
     });

--- a/src/worldmap.ts
+++ b/src/worldmap.ts
@@ -122,13 +122,13 @@ export default class WorldMap {
   }
 
   filterEmptyAndZeroValues(data) {
-    const minValue = this.ctrl.panel.minValue;
-    const maxValue = this.ctrl.panel.maxValue;
+    const minValue = this.ctrl.panel.minValue || parseInt(this.ctrl.panel.replaceVariables('$minDisplayValue'));
+    const maxValue = this.ctrl.panel.maxValue || parseInt(this.ctrl.panel.replaceVariables('$maxDisplayValue'));
     return _.filter(data, o => {
       return !(this.ctrl.panel.hideEmpty && _.isNil(o.value)) 
           && !(this.ctrl.panel.hideZero && o.value === 0)
-          && ([undefined, ''].includes(minValue) || o.value >= minValue)
-          && ([undefined, ''].includes(maxValue) || o.value <= maxValue)
+          && ([undefined, NaN, 0, ''].includes(minValue) || o.value >= minValue)
+          && ([undefined, NaN, ''].includes(maxValue) || o.value <= maxValue)
     });
   }
 

--- a/src/worldmap.ts
+++ b/src/worldmap.ts
@@ -127,6 +127,8 @@ export default class WorldMap {
     return _.filter(data, o => {
       return !(this.ctrl.panel.hideEmpty && _.isNil(o.value)) 
           && !(this.ctrl.panel.hideZero && o.value === 0)
+          // The result of parseInt in case of "No Limit" or any other numberless string will be a NaN. 
+          // In that case all "not numbers" should invalidate the filter and ignored.
           && ([undefined, NaN, 0, ''].includes(minValue) || o.value >= minValue)
           && ([undefined, NaN, ''].includes(maxValue) || o.value <= maxValue)
     });


### PR DESCRIPTION
Added two new variables: 

$minDisplaySize and $maxDisplaySize, when defined on the dashboard level, they'll filter out any data point < $minDisplaySize and >$maxDisplaySize.

My suggestion is to create custom filters with limited choices for both variables. On the min field, 0 will override the filter and, on the max side, any text will be considered "not a number" and will override the filter altogether. 

Signed-off-by: Eduardo Elias Saleh <du7@msn.com>